### PR TITLE
Catching error if parsing error due to wrong separator

### DIFF
--- a/validator/main_validator.py
+++ b/validator/main_validator.py
@@ -660,7 +660,7 @@ class PGSMetadataValidator():
                         try:
                             current_metric['estimate'] = float(val)
                         except ValueError:
-                            self.report_error(spread_sheet_name, row_id, f'Failed to extract metric(s). Is the correct separator (;) used?')
+                            self.report_error(spread_sheet_name, row_id, f'Failed to extract metric estimate value (Expected float but found "{val}"). Is the correct separator (;) used?')
                         current_metric['unit'] = unit
                 current_metric['se'] = matches_parentheses[0]
             # Extract interval

--- a/validator/main_validator.py
+++ b/validator/main_validator.py
@@ -657,7 +657,10 @@ class PGSMetadataValidator():
                 except:
                      if " " in val:
                         val, unit = val.split(" ", 1)
-                        current_metric['estimate'] = float(val)
+                        try:
+                            current_metric['estimate'] = float(val)
+                        except ValueError:
+                            self.report_error(spread_sheet_name, row_id, f'Failed to extract metric(s). Is the correct separator (;) used?')
                         current_metric['unit'] = unit
                 current_metric['se'] = matches_parentheses[0]
             # Extract interval


### PR DESCRIPTION
The validator raises an uncaught error trying to convert a str to float if the wrong separator is used in Other metrics.