### PR TITLE
Deposition app REST validator

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -22,3 +22,6 @@ pgs-catalog-cred.json_template
 pgs_metadata_validator.py
 LICENSE.md
 README.md
+
+dist
+.idea

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 import io
+import os
 from validator.main_validator import PGSMetadataValidator
 
 app = Flask(__name__)
@@ -11,6 +12,19 @@ app.config['MAX_CONTENT_LENGTH'] = 4 * 1000 * 1000
 # CORS settings
 CORS(app)
 cors = CORS(app, resources={r"/": {"origins": "*"}})
+
+
+if not os.getenv('GAE_APPLICATION', None):
+    app_settings = os.path.join('./', 'app.yaml')
+    if os.path.exists(app_settings):
+        import yaml
+        with open(app_settings) as secrets_file:
+            secrets = yaml.load(secrets_file, Loader=yaml.FullLoader)
+            for keyword in secrets['env_variables']:
+                os.environ[keyword] = secrets['env_variables'][keyword]
+    else:
+        print("Error: missing app.yaml file")
+        exit(1)
 
 
 @app.route("/robots.txt")

--- a/main.py
+++ b/main.py
@@ -46,19 +46,21 @@ def validate_metadata():
     metadata_validator.post_parsing_checks()
 
     valid = True
-    depositon_report = {}
+    public_error_report = {}
+    public_warning_report = {}
     if metadata_validator.report['error']:
         valid = False
         error_report = metadata_validator.report['error']
-        add_report_error(depositon_report, error_report)
+        add_report_error(public_error_report, error_report)
 
     if metadata_validator.report['warning']:
         warning_report = metadata_validator.report['warning']
-        add_report_error(depositon_report, warning_report)
+        add_report_error(public_warning_report, warning_report)
 
     response = {
         "valid": valid,
-        "errorMessages": depositon_report
+        "errorMessages": public_error_report,
+        "warningMessages": public_warning_report
     }
 
     return jsonify(response)

--- a/main.py
+++ b/main.py
@@ -33,6 +33,11 @@ def robots_dot_txt():
     return "User-agent: *\nDisallow: /"
 
 
+@app.route('/', methods=['GET'])
+def home():
+    return "<h1>PGS Catalog metadata validator</h1><p>This service validates the Metadata files schema and content.</p>"
+
+
 def add_report_error(depositon_report: dict, report: dict):
     for spreadsheet in report:
         errors = []

--- a/main.py
+++ b/main.py
@@ -62,6 +62,7 @@ def validate_metadata():
         metadata_validator.parse_spreadsheets()
         metadata_validator.parse_publication()
         metadata_validator.parse_scores()
+        score_names = list(metadata_validator.parsed_scores.keys())
         metadata_validator.parse_cohorts()
         metadata_validator.parse_performances()
         metadata_validator.parse_samples()
@@ -93,7 +94,8 @@ def validate_metadata():
     response = {
         "valid": valid,
         "errorMessages": public_error_report,
-        "warningMessages": public_warning_report
+        "warningMessages": public_warning_report,
+        "scoreNames": score_names,
     }
 
     return jsonify(response)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,11 @@ CORS(app)
 cors = CORS(app, resources={r"/": {"origins": "*"}})
 
 
+@app.route("/robots.txt")
+def robots_dot_txt():
+    return "User-agent: *\nDisallow: /"
+
+
 def add_report_error(depositon_report: dict, report: dict):
     for spreadsheet in report:
         errors = []

--- a/main.py
+++ b/main.py
@@ -1,96 +1,57 @@
-#!flask/bin/python
-import os
-from flask import Flask, request, jsonify
+from flask import Flask, jsonify, request
 from flask_cors import CORS
+import io
 from validator.main_validator import PGSMetadataValidator
 
-app = Flask(__name__, static_url_path='/')
+app = Flask(__name__)
+app.config["DEBUG"] = True
+# File size limit set to 4MB (average is 400-500K)
+app.config['MAX_CONTENT_LENGTH'] = 4 * 1000 * 1000
 
 # CORS settings
 CORS(app)
 cors = CORS(app, resources={r"/": {"origins": "*"}})
 
-if not os.getenv('GAE_APPLICATION', None):
-    app_settings = os.path.join('./', 'app.yaml')
-    if os.path.exists(app_settings):
-        import yaml
-        with open(app_settings) as secrets_file:
-            secrets = yaml.load(secrets_file, Loader=yaml.FullLoader)
-            for keyword in secrets['env_variables']:
-                os.environ[keyword] = secrets['env_variables'][keyword]
-    else:
-        print("Error: missing app.yaml file")
-        exit(1)
+
+def format_report_error(report: dict) -> list:
+    errors = []
+    for spreadsheet in report:
+        for message in report[spreadsheet]:
+            formatted_message = spreadsheet
+            if report[spreadsheet][message][0]:
+                formatted_message += " (lines: {})".format(report[spreadsheet][message][0])
+            formatted_message += ": " + message
+            errors.append(formatted_message)
+    return errors
 
 
-@app.route("/robots.txt")
-def robots_dot_txt():
-    return "User-agent: *\nDisallow: /"
+@app.route('/validate_metadata', methods=['POST'])
+def validate_metadata():
+    file = request.files['file']
+    bin_file = io.BytesIO(file.read())
+    metadata_validator = PGSMetadataValidator(bin_file, False)
+    metadata_validator.parse_spreadsheets()
+    metadata_validator.parse_publication()
+    metadata_validator.parse_scores()
+    metadata_validator.parse_cohorts()
+    metadata_validator.parse_performances()
+    metadata_validator.parse_samples()
+    metadata_validator.post_parsing_checks()
 
-
-@app.route('/', methods=['GET'])
-def home():
-    return "<h1>PGS Catalog metadata validator</h1><p>This service validates the Metadata files schema and content.</p>"
-
-
-@app.route('/validate', methods=['POST'])
-def post_file():
-
-    response = {}
-    post_json = request.get_json()
-    #print("post_json: "+str(post_json))
-
-    filename = post_json['filename']
-
-    # Check file extension
-    expected_file_extension = 'xlsx'
-    filename_only = os.path.basename(filename)
-    extension = filename_only.split('.')[-1]
-    if extension != expected_file_extension:
-        error_msg = { 'message': f'The expected file extension is [.{expected_file_extension}] but the given file name is "{filename_only}".'}
-        response = {'status': 'failed', 'error': {} }
-        response['error']['General'] = [ error_msg ]
-        return jsonify(response)
-
-    metadata_validator = PGSMetadataValidator(filename, 1)
-    loaded_spreadsheets = metadata_validator.parse_spreadsheets()
-    if loaded_spreadsheets:
-        metadata_validator.parse_publication()
-        metadata_validator.parse_scores()
-        metadata_validator.parse_cohorts()
-        metadata_validator.parse_performances()
-        metadata_validator.parse_samples()
-        metadata_validator.post_parsing_checks()
-
-    status = 'success'
+    valid = True
+    errors = []
     if metadata_validator.report['error']:
-        status = 'failed'
-        response['error'] = {}
+        valid = False
         error_report = metadata_validator.report['error']
-        for error_spreadsheet in error_report:
-            response['error'][error_spreadsheet] = []
-            for error_msg in error_report[error_spreadsheet]:
-                error_entry = { 'message': error_msg }
-                if error_report[error_spreadsheet][error_msg][0] != None:
-                    error_entry['lines'] = error_report[error_spreadsheet][error_msg]
-                response['error'][error_spreadsheet].append(error_entry)
+        errors.extend(format_report_error(error_report))
 
     if metadata_validator.report['warning']:
-        response['warning'] = {}
         warning_report = metadata_validator.report['warning']
-        for warning_spreadsheet in warning_report:
-            response['warning'][warning_spreadsheet] = []
-            for warning_msg in warning_report[warning_spreadsheet]:
-                warning_entry = { 'message': warning_msg }
-                if warning_report[warning_spreadsheet][warning_msg][0] != None:
-                    warning_entry['lines'] = warning_report[warning_spreadsheet][warning_msg]
-                response['warning'][warning_spreadsheet].append(warning_entry)
+        errors.extend(format_report_error(warning_report))
 
-    response['status'] = status
-    #os.remove(metadata_filename)
+    response = {
+        "valid": valid,
+        "errors": errors
+    }
 
     return jsonify(response)
-
-if __name__ == '__main__':
-    app.run(debug=False)#, port=5000)
-    #app.run(debug=True, port=5000)


### PR DESCRIPTION
Required output:
`private boolean valid;`
`private Map<String, List<String>> errorMessages;`

This version doesn't require a gcloud bucket as it uses BytesIO as input of the validator